### PR TITLE
Pass Output type to Submission in onSubmitt

### DIFF
--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -156,7 +156,7 @@ export interface FormConfig<
 		event: FormEvent<HTMLFormElement>,
 		context: {
 			formData: FormData;
-			submission: Submission;
+			submission: Submission<Output>;
 			action: string;
 			encType: ReturnType<typeof getFormEncType>;
 			method: ReturnType<typeof getFormMethod>;


### PR DESCRIPTION
Make `context.submission` aware of the `Output` type.

Now we should be able to have intellisense with `onSubmit` `context` param.

Ex:
```ts
onSubmit(event, context) {
    if (context.submission.value?.step === "send-otp") {
        // do something
    }
},
```